### PR TITLE
Remove error thrown when overwrite is false and param exists

### DIFF
--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ssm"
@@ -79,6 +81,8 @@ func (svc *Impl) PutParameters(path string, params map[string]string, overwrite 
 			}
 			return true
 		})
+
+		log.Debugf("Found %d existing parameters", len(existingParams))
 	}
 
 	for key, param := range params {
@@ -86,7 +90,8 @@ func (svc *Impl) PutParameters(path string, params map[string]string, overwrite 
 
 		if !overwrite {
 			if _, ok := existingParams[key]; ok {
-				return fmt.Errorf("cowardly refusing to overwrite: %s", paramPath)
+				log.Debugf("Found an existing parameter under %s", paramPath)
+				continue
 			}
 		}
 
@@ -98,6 +103,7 @@ func (svc *Impl) PutParameters(path string, params map[string]string, overwrite 
 			Value:     aws.String(param),
 		}
 
+		log.Debugf("Updating %s parameter", paramPath)
 		_, err = svc.SSMClient.PutParameter(putParameterInput)
 	}
 

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Service", func() {
 		Expect(err).Should(BeNil())
 	})
 
-	It("Should get all parameters from path", func() {
+	It("should get all parameters from path", func() {
 		testutils.MockGetParametersByPath(client, inputPath, nil)
 
 		params, err := svc.GetParameters(inputPath)
@@ -38,7 +38,7 @@ var _ = Describe("Service", func() {
 		Expect(params).Should(Equal(testutils.ParametersMap))
 	})
 
-	It("Should copy all params to the new path", func() {
+	It("should copy all params to the new path", func() {
 		testutils.MockGetParametersByPath(client, inputPath, []*ssm.Parameter{})
 		testutils.ExpectAllParametersToBePut(client, outputPath, false)
 
@@ -46,14 +46,19 @@ var _ = Describe("Service", func() {
 		Expect(err).Should(BeNil())
 	})
 
-	It("Should cowardly refuse to overwrite existing params", func() {
+	It("should cowardly refuse to overwrite existing params", func() {
 		testutils.MockGetParametersByPath(client, outputPath, nil)
 
+		client.
+			EXPECT().
+			PutParameter(gomock.Any()).
+			Times(0)
+
 		err := svc.PutParameters(outputPath, testutils.ParametersMap, false)
-		Expect(err).ShouldNot(BeNil())
+		Expect(err).Should(BeNil())
 	})
 
-	It("Should overwrite existing params", func() {
+	It("should overwrite existing params", func() {
 		client.
 			EXPECT().
 			GetParametersByPathPages(gomock.Any(), gomock.Any()).

--- a/ssm2ssm_test.go
+++ b/ssm2ssm_test.go
@@ -5,6 +5,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/aws/aws-sdk-go/service/ssm"
+	"github.com/golang/mock/gomock"
 
 	"github.com/shopsmart/ssm2ssm"
 	"github.com/shopsmart/ssm2ssm/internal/testutils"
@@ -39,12 +40,17 @@ var _ = Describe("Ssm2ssm", func() {
 		Expect(err).Should(BeNil())
 	})
 
-	It("Should cowardly refuse to copy the parameters from input to output", func() {
+	It("Should skip over parameters that already exist", func() {
 		testutils.MockGetParametersByPath(client, InputPath, nil)
 		testutils.MockGetParametersByPath(client, OutputPath, nil)
 
+		client.
+			EXPECT().
+			PutParameter(gomock.Any()).
+			Times(0)
+
 		err = ssm2ssm.Copy(svc, InputPath, OutputPath, false)
-		Expect(err).ShouldNot(BeNil())
+		Expect(err).Should(BeNil())
 	})
 
 	It("Should overwrite the parameters currently under output", func() {


### PR DESCRIPTION
## Problem

<!-- What are you trying to solve? -->

We would like the application to simply not update the parameter when overwrite is false rather than error out.

## Solution

<!-- How does this change fix the problem? -->

Removes the error returned when overwrite is false and paramter is already present.
