### PR TITLE
Removes comments using archive.replacements

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,13 +19,6 @@ builds:
     main: ./cmd/ssm2ssm
     ldflags:
       - "-X main.version={{ incpatch .Version }}"
-# archives:
-#   - replacements:
-#       darwin: Darwin
-#       linux: Linux
-#       # windows: Windows
-#       386: i386
-#       amd64: x86_64
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
## Problem

<!-- What are you trying to solve? -->

Goreleaser has deprecated and removed the archive.replacements

## Solution

<!-- How does this change fix the problem? -->

Removes the comments using arhive.replacements

## Notes


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205207183181243